### PR TITLE
Doing propType checking at runtime is bad

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ Goal: Get familiar with JSX syntax, component structure, and passing props
 
 Tasks: 
 * Send a `shouldDisplayImage` prop into the `Instructions` component that determines whether or not to display the H4I logo 
-* Make sure to set the `PropTypes` accordingly anytime you pass in props to a component. [Hint](https://egghead.io/lessons/react-validate-custom-react-component-props-with-proptypes)
 
 Once you're done, make a commit to your branch with the message "Part 1 Complete." Do the same for each part so your tech lead can follow your process for each step.
 


### PR DESCRIPTION
This is pretty much deprecated. The reason the React team moved it to its own repo is to make it optional and discourage its use further. 

If you'd like to do prop type checking, do it statically at compile time with something like Flow (https://flow.org/en/docs/react/components/) or don't do it at all. I don't think we should encourage using the `prop-types` package