### PR TITLE
remove intermediary export file

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { Instructions } from './components'
+import Instructions from './components/Instructions.component'
 import './styles/app.css'
 
 class App extends Component {

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,3 +1,0 @@
-import Instructions from './Instructions.component'
-
-export { Instructions }


### PR DESCRIPTION
@vrunjeti Having intermediary export files is considered bad practice in general. Couple reasons.

1. if your intermediary file exports 10 components, but you only ever use 2 or 3 of them, you're simply bundling extra dead code into your bundle unless you set up [webpack treeshaking](https://webpack.js.org/guides/tree-shaking/) and that's not the case in this repo
2. It's very easy and tempting for someone to just do `import * as Components from './components' when they don't know what they need, simply increasing complexity.

I understand that it's "nicer" to see a single `import` statement from a directory, but I argue it's clearer to do something like this:

```javascript
// external
import React from 'react';
...
// components
import A from './components/A';
import B from './components/B';
...
// utils
...
```

As a plus side, you get one fewer file in your repo 🎉 